### PR TITLE
Feature/#25 tanstack query

### DIFF
--- a/src/components/commons/Loading.tsx
+++ b/src/components/commons/Loading.tsx
@@ -1,0 +1,7 @@
+export default function Loading() {
+  return (
+    <div className="flex justify-center mt-20">
+      <div className="loading" />
+    </div>
+  );
+}

--- a/src/components/features/auth/ProfileForm.tsx
+++ b/src/components/features/auth/ProfileForm.tsx
@@ -9,9 +9,7 @@ export default function ProfileForm() {
   return (
     <form onSubmit={onSubmitHandler} className="m-3 space-y-4 [&_input]:mb-4 [&_label]:text-sm">
       <label htmlFor="avatar">프로필</label>
-      {initialFormData?.avatar && (
-        <ImageInput id="avatar" name="avatar" defaultValue={initialFormData.avatar} />
-      )}
+      <ImageInput id="avatar" name="avatar" defaultValue={initialFormData.avatar} />
       <label htmlFor="nickname">닉네임</label>
       <AuthInput
         id="nickname"

--- a/src/components/features/developer-test/ResultsCard.tsx
+++ b/src/components/features/developer-test/ResultsCard.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { forwardRef } from "react";
 import AvatarIcon from "@/components/commons/AvatarIcon";
 import Button from "@/components/commons/Button";
 import { developerTypes } from "@/data/developer-type.data";
@@ -15,8 +15,11 @@ interface ResultsCardProps {
   isMine: boolean;
 }
 
-export default React.memo(ResultsCard);
-function ResultsCard({ id, nickname, avatar, type, isMine }: ResultsCardProps) {
+export default React.memo(forwardRef<HTMLAnchorElement, ResultsCardProps>(ResultsCard));
+function ResultsCard(
+  { id, nickname, avatar, type, isMine }: ResultsCardProps,
+  ref?: React.ForwardedRef<HTMLAnchorElement>
+) {
   const { mutate: deleteTestResult } = useDeleteTestResultMutation();
   if (!isValidDeveloperTypeId(type)) return null;
 
@@ -35,6 +38,7 @@ function ResultsCard({ id, nickname, avatar, type, isMine }: ResultsCardProps) {
     <Link
       to={`/results/${id}`}
       className="block bg-primary/10 p-4 rounded-lg border border-primary"
+      ref={ref}
     >
       <div className="flex justify-between w-full overflow-hidden">
         <h3 className="shrink flex min-w-0 text-xl font-semibold gap-2 items-center mb-4">

--- a/src/components/layouts/Header.tsx
+++ b/src/components/layouts/Header.tsx
@@ -1,5 +1,6 @@
 import Button from "@/components/commons/Button";
 import StyledLink from "@/components/commons/StyledLink";
+import { prefetchProfile } from "@/libs/api/useAuth.api";
 import { useTokenStore } from "@/stores/token.store";
 import { useUserStore } from "@/stores/user.store";
 import { useNavigate } from "react-router-dom";
@@ -28,9 +29,12 @@ function AuthorizedSession() {
     clearUserInfo();
     navigate("/");
   }
+
   return (
     <div className="relative flex items-center pr-20 gap-4">
-      <StyledLink to="/profile">프로필</StyledLink>
+      <StyledLink to="/profile" onMouseEnter={prefetchProfile}>
+        프로필
+      </StyledLink>
       <StyledLink to="/test">테스트</StyledLink>
       <StyledLink to="/results">결과 보기</StyledLink>
       <Button

--- a/src/config/Router.tsx
+++ b/src/config/Router.tsx
@@ -42,7 +42,14 @@ const protectedRoute = [
         children: [
           { path: "profile", element: <ProfilePage /> },
           { path: "test", element: <TestPage /> },
-          { path: "results", element: <ResultsPage /> },
+          {
+            path: "results",
+            element: (
+              <Suspense fallback={<Loading />}>
+                <ResultsPage />
+              </Suspense>
+            ),
+          },
         ],
       },
     ],

--- a/src/config/Router.tsx
+++ b/src/config/Router.tsx
@@ -8,6 +8,8 @@ import ProfilePage from "@/pages/auth/ProfilePage";
 import TestPage from "@/pages/developer-test/TestPage";
 import ResultDetailPage from "@/pages/developer-test/ResultDetailPage";
 import ResultsPage from "@/pages/developer-test/ResultsPage";
+import { Suspense } from "react";
+import Loading from "@/components/commons/Loading";
 
 const publicRoute = [
   {
@@ -17,7 +19,14 @@ const publicRoute = [
       { path: "", element: <HomePage /> },
       { path: "sign-in", element: <SignInPage /> },
       { path: "sign-up", element: <SignUpPage /> },
-      { path: "results/:id", element: <ResultDetailPage /> },
+      {
+        path: "results/:id",
+        element: (
+          <Suspense fallback={<Loading />}>
+            <ResultDetailPage />
+          </Suspense>
+        ),
+      },
     ],
   },
 ];

--- a/src/constants/query-key.constant.ts
+++ b/src/constants/query-key.constant.ts
@@ -1,5 +1,6 @@
 export const QueryKeys = {
   MEMBER_ME: ["member-me"],
+  DEVELOPER_INFINITE_RESULTS: ["developer-results", "infinite"],
   DEVELOPER_RESULTS: (page: number, limit: number) => ["developer-results", page, limit],
   DEVELOPER_DETAIL_RESULT: (resultId: number) => ["developer-detail-result", resultId],
 };

--- a/src/libs/api/useAuth.api.ts
+++ b/src/libs/api/useAuth.api.ts
@@ -10,7 +10,7 @@ import {
   ProfileRequestDto,
   ProfileResponseDto,
 } from "@/types/dto/auth.dto";
-import { useMutation, useQuery } from "@tanstack/react-query";
+import { useMutation, useSuspenseQuery } from "@tanstack/react-query";
 
 export function useSignUpMutate() {
   return useMutation({
@@ -37,13 +37,26 @@ export function useSignInMutate() {
   });
 }
 
+export function prefetchProfile() {
+  return queryClient.prefetchQuery({
+    queryKey: QueryKeys.MEMBER_ME,
+    queryFn: async (): Promise<ProfileResponseDto> => {
+      const response = await authServer.get<ProfileResponseDto>("/user");
+      console.log("asdf");
+      return response.data;
+    },
+    staleTime: 60 * 1000,
+  });
+}
+
 export function useProfileQuery() {
-  return useQuery({
+  return useSuspenseQuery({
     queryKey: QueryKeys.MEMBER_ME,
     queryFn: async (): Promise<ProfileResponseDto> => {
       const response = await authServer.get<ProfileResponseDto>("/user");
       return response.data;
     },
+    staleTime: 60 * 1000,
   });
 }
 

--- a/src/libs/api/useTestResult.api.ts
+++ b/src/libs/api/useTestResult.api.ts
@@ -28,6 +28,24 @@ export function useTestResultByPageQuery({ page = 0, limit = 20 }: PageDto) {
   });
 }
 
+export async function prefetchTestResult(id: number) {
+  await queryClient.prefetchQuery({
+    queryKey: QueryKeys.DEVELOPER_DETAIL_RESULT(id),
+    queryFn: async (): Promise<TestResult> => {
+      const response = await jsonServer.get(`/developer-tests/${id}?_expand=user`);
+      const data: TestResultResponseDto = response.data;
+
+      return {
+        id: data.id,
+        type: data.type,
+        userId: data.userId,
+        avatar: data.user.avatar,
+        nickname: data.user.nickname,
+      };
+    },
+  });
+}
+
 export function useTestResultQuery({ id }: { id: number }) {
   return useQuery({
     queryKey: QueryKeys.DEVELOPER_DETAIL_RESULT(id),

--- a/src/libs/api/useTestResult.api.ts
+++ b/src/libs/api/useTestResult.api.ts
@@ -7,7 +7,7 @@ import {
   TestResultRequestDto,
   TestResultResponseDto,
 } from "@/types/dto/test-result.dto";
-import { useMutation, useQuery } from "@tanstack/react-query";
+import { useMutation, useQuery, useSuspenseQuery } from "@tanstack/react-query";
 
 export function useTestResultByPageQuery({ page = 0, limit = 20 }: PageDto) {
   return useQuery({
@@ -47,7 +47,7 @@ export async function prefetchTestResult(id: number) {
 }
 
 export function useTestResultQuery({ id }: { id: number }) {
-  return useQuery({
+  return useSuspenseQuery({
     queryKey: QueryKeys.DEVELOPER_DETAIL_RESULT(id),
     queryFn: async (): Promise<TestResult> => {
       const response = await jsonServer.get(`/developer-tests/${id}?_expand=user`);

--- a/src/libs/api/useTestResult.api.ts
+++ b/src/libs/api/useTestResult.api.ts
@@ -65,13 +65,12 @@ export function useTestResultByPageQuery({ page = 0, limit = 20 }: PageDto) {
   });
 }
 
-export async function prefetchTestResult(id: number) {
-  await queryClient.prefetchQuery({
+export function prefetchTestResult(id: number) {
+  return queryClient.prefetchQuery({
     queryKey: QueryKeys.DEVELOPER_DETAIL_RESULT(id),
     queryFn: async (): Promise<TestResult> => {
       const response = await jsonServer.get(`/developer-tests/${id}?_expand=user`);
       const data: TestResultResponseDto = response.data;
-
       return {
         id: data.id,
         type: data.type,
@@ -90,7 +89,6 @@ export function useTestResultQuery({ id }: { id: number }) {
     queryFn: async (): Promise<TestResult> => {
       const response = await jsonServer.get(`/developer-tests/${id}?_expand=user`);
       const data: TestResultResponseDto = response.data;
-
       return {
         id: data.id,
         type: data.type,
@@ -99,6 +97,7 @@ export function useTestResultQuery({ id }: { id: number }) {
         nickname: data.user.nickname,
       };
     },
+    staleTime: 60 * 1000,
   });
 }
 

--- a/src/libs/hooks/useProfileForm.ts
+++ b/src/libs/hooks/useProfileForm.ts
@@ -15,7 +15,6 @@ export default function useProfileForm() {
   const { mutate: updateJsonUser } = useUpdateUserMutation();
 
   const initialFormData = useMemo(() => {
-    if (!profile) return { nickname: "", avatar: "" };
     return { nickname: profile.nickname, avatar: profile.avatar };
   }, [profile]);
 

--- a/src/pages/developer-test/ResultDetailPage.tsx
+++ b/src/pages/developer-test/ResultDetailPage.tsx
@@ -9,10 +9,8 @@ import { useUserStore } from "@/stores/user.store";
 
 export default function ResultDetailPage() {
   const { id: testResultId } = useParams();
-  const { data: result, isPending } = useTestResultQuery({ id: Number(testResultId) });
+  const { data: result } = useTestResultQuery({ id: Number(testResultId) });
   const user = useUserStore().user;
-
-  if (!result || isPending) return <p className="text-center">Loading...</p>;
 
   const developerType = developerTypes[result.type];
   async function handleShareLinkClick() {

--- a/src/pages/developer-test/ResultsPage.tsx
+++ b/src/pages/developer-test/ResultsPage.tsx
@@ -1,23 +1,50 @@
+import Loading from "@/components/commons/Loading";
 import ResultsCard from "@/components/features/developer-test/ResultsCard";
-import { useTestResultByPageQuery } from "@/libs/api/useTestResult.api";
+import { useInfiniteTestResults } from "@/libs/api/useTestResult.api";
 import { useUserStore } from "@/stores/user.store";
+import { Fragment, useCallback, useRef } from "react";
 
 export default function ResultsPage() {
   const user = useUserStore().user;
-  const { data: developerTestResults } = useTestResultByPageQuery({});
+  const { data, fetchNextPage, hasNextPage, isFetchingNextPage } = useInfiniteTestResults({
+    limit: 20,
+  });
+
+  const observerRef = useRef<IntersectionObserver>(null);
+  const lastItemRef = useCallback(
+    (node: HTMLElement | null) => {
+      if (observerRef.current) observerRef.current.disconnect();
+
+      observerRef.current = new IntersectionObserver((entries) => {
+        if (entries[0].isIntersecting && hasNextPage && !isFetchingNextPage) fetchNextPage();
+      });
+      if (node) observerRef.current.observe(node);
+    },
+    [hasNextPage, isFetchingNextPage, fetchNextPage]
+  );
 
   return (
     <div className="bg-white p-8 rounded-lg shadow-lg max-w-2xl mx-auto">
       <h1 className="text-2xl font-bold mb-8">모든 테스트 결과</h1>
       <ul className="[&>*]:mb-4">
-        {developerTestResults && developerTestResults.length !== 0 ? (
-          developerTestResults.map((info) => (
-            <ResultsCard key={info.id} {...info} isMine={user.id === info.userId} />
-          ))
-        ) : (
-          <p>테스트 결과가 없습니다!</p>
-        )}
+        {data.pages.map((page, pageIdx) => (
+          <Fragment key={pageIdx}>
+            {page.results.map((info, idx) => {
+              if (pageIdx !== data.pages.length - 1 || idx !== page.results.length - 1)
+                return <ResultsCard key={info.id} {...info} isMine={user.id === info.userId} />;
+              return (
+                <ResultsCard
+                  key={info.id}
+                  {...info}
+                  isMine={user.id === info.userId}
+                  ref={lastItemRef}
+                />
+              );
+            })}
+          </Fragment>
+        ))}
       </ul>
+      {hasNextPage && <Loading />}
     </div>
   );
 }

--- a/src/pages/developer-test/TestPage.tsx
+++ b/src/pages/developer-test/TestPage.tsx
@@ -5,7 +5,7 @@ import TestProgress from "@/components/features/developer-test/TestProgress";
 import { initialQuestion, questions } from "@/data/questions.data";
 import { calculateDeveloperType, isValidAnswerTypeId } from "@/libs/utils/developer-test.utils";
 import { PersonalityTypeScores } from "@/types/developer-test.type";
-import { useCreateTestResultMutation } from "@/libs/api/useTestResult.api";
+import { prefetchTestResult, useCreateTestResultMutation } from "@/libs/api/useTestResult.api";
 import { useUserStore } from "@/stores/user.store";
 
 export default function TestPage() {
@@ -33,7 +33,8 @@ export default function TestPage() {
     createResultTest(
       { type: developerTypeId, userId: user.id },
       {
-        onSuccess: (res) => {
+        onSuccess: async (res) => {
+          await prefetchTestResult(res.id);
           navigate(`/results/${res.id}`);
         },
       }

--- a/src/pages/developer-test/TestPage.tsx
+++ b/src/pages/developer-test/TestPage.tsx
@@ -33,8 +33,8 @@ export default function TestPage() {
     createResultTest(
       { type: developerTypeId, userId: user.id },
       {
-        onSuccess: async (res) => {
-          await prefetchTestResult(res.id);
+        onSuccess: (res) => {
+          prefetchTestResult(res.id);
           navigate(`/results/${res.id}`);
         },
       }

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -20,6 +20,13 @@
 
   html {
     background-color: var(--background-color);
+
+    -ms-overflow-style: none;
+    scrollbar-width: none;
+
+    &::-webkit-scrollbar {
+      display: none;
+    }
   }
 }
 

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -30,3 +30,33 @@
   --color-secondary: var(--secondary-color);
   --color-background: var(--background-color);
 }
+
+@layer components {
+  .loading {
+    width: 100px;
+    aspect-ratio: 1;
+    border-radius: 50%;
+    border: 8px solid #0000;
+    border-right-color: #ff5a5f97;
+    position: relative;
+    animation: loading-animation 0.5s infinite linear;
+  }
+  .loading:before,
+  .loading:after {
+    content: "";
+    position: absolute;
+    inset: -8px;
+    border-radius: 50%;
+    border: inherit;
+    animation: inherit;
+    animation-duration: 2s;
+  }
+  .loading:after {
+    animation-duration: 4s;
+  }
+  @keyframes loading-animation {
+    100% {
+      transform: rotate(1turn);
+    }
+  }
+}


### PR DESCRIPTION
## 💡 관련이슈
- close #25 

## 🍀 작업 요약
- 테스트 결과를 불러오는 페이지에서 useSuspenseInfiniteQuery 적용
- 프로필, 테스트 결과지로 이동하는 페이지에 useSuspenseQuery 및 prefetch 적용

## 💬 리뷰 요구 사항
- 프로필을 불러오는 곳에서 useSuspenseQuery를 사용하였지만, 정보가 불러오기 전까지 이동은 하지 않았으면 해서 따로 suspense 태그를 통해 fallback을 구현하지 않았습니다.
- 구현했어야할까요?
- 리뷰 예상 시간 : `10분`

## 💛 미리보기
- 디자인 변경사항은 없습니다.
